### PR TITLE
Implement mixed rounding and percentage leniency for numeric answers

### DIFF
--- a/app.js
+++ b/app.js
@@ -266,6 +266,14 @@ function renderQuestion(){
 
 function withinLeniency(input, correct, pct){
   if (isNaN(input)) return false;
+
+  // Always accept if rounded values match
+  if (Math.round(input) === Math.round(correct)) return true;
+
+  // For small numbers (<20), rounding match is the only leniency
+  if (correct < 20) return false;
+
+  // For larger numbers, fall back to percentage-based leniency
   const diff = Math.abs(input - correct);
   const allowed = (pct/100) * Math.max(1, correct);
   return diff <= allowed;


### PR DESCRIPTION
## Summary
- Accept numeric answers that match the correct value when rounded
- Use rounding-only leniency for answers below 20, percentage tolerance for larger values

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7c17c55dc832ba1444e8f4c870ef7